### PR TITLE
Update podspec file and make it rely on package.json.

### DIFF
--- a/src/ios/RNSpringScrollView.podspec
+++ b/src/ios/RNSpringScrollView.podspec
@@ -1,22 +1,18 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "../package.json")))
 
 Pod::Spec.new do |s|
   s.name         = "RNSpringScrollView"
-  s.version      = "1.0.0"
-  s.summary      = "RNSpringScrollView"
-  s.description  = <<-DESC
-                  React Native Spring ScrollView V2 is a high performance cross-platform native bounces ScrollView for React Native.(iOS & Android)
-                   DESC
+  s.version      = package["version"]
+  s.summary      = package["description"]
   s.homepage     = "https://github.com/bolan9999/react-native-spring-scrollview"
-  s.license      = "MIT"
-  s.license      = { :type => "MIT", :file => "LICENSE" }
-  s.author             = { "bolan9999" => "shanshang130@gmail.com" }
+  s.license      = package["license"]
+  s.author       = { "bolan9999" => "shanshang130@gmail.com" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/bolan9999/react-native-spring-scrollview.git", :tag => "master" }
-  s.source_files  = "src/ios/SpringScrollView/**/*.{h,m}"
+  s.source       = { :git => "https://github.com/bolan9999/react-native-spring-scrollview.git", :tag => s.version }
+  s.source_files  = "SpringScrollView/**/*.{h,m}"
   s.requires_arc = true
 
   s.dependency "React"
-
 end
-
-  


### PR DESCRIPTION
Hi,

first of all I'd like to thank you for all the work you put into this project. `react-native-spring-scrollview` and `react-native-large-list` are both of great value to a feature we implemented in one of our apps.

We've been using it with CocoaPods because it simplifies our building and deploying processes. The current version of podspec file has a misconfiguration that prevents it from being compiled. It relies on the path based on the root of the repo instead of the root of the npm package; `src/ios/SpringScrollView/**/*.{h,m}` and not `SpringScrollView/**/*.{h,m}`.
In this PR, the source files configuration was fixed and also some more work to make other configurations to be read from `package.json`, so no additional work is required when a new version is to be released.

Please, let me know your thoughts and how can I help to get this merge in.

Thank you!