### PR TITLE
[f]将react_native_AsyncStorage换成_官方独立库

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@react-native-community/async-storage": "^1.6.3",
     "lottie-ios": "3.1.3",
     "lottie-react-native": "^3.2.1",
     "react": "16.9.0",

--- a/src/Customize/WithLastDateFooter.js
+++ b/src/Customize/WithLastDateFooter.js
@@ -8,7 +8,8 @@
  */
 
 import React from "react";
-import { Text, StyleSheet, AsyncStorage } from "react-native";
+import { Text, StyleSheet } from "react-native";
+import AsyncStorage from "@react-native-community/async-storage";
 import { HeaderStatus } from "../RefreshHeader";
 import {NormalFooter} from "../NormalFooter";
 

--- a/src/Customize/WithLastDateHeader.js
+++ b/src/Customize/WithLastDateHeader.js
@@ -8,7 +8,8 @@
  */
 
 import React from "react";
-import { Text, StyleSheet, AsyncStorage } from "react-native";
+import { Text, StyleSheet } from "react-native";
+import AsyncStorage from "@react-native-community/async-storage";
 import { NormalHeader } from "../NormalHeader";
 import { HeaderStatus } from "../RefreshHeader";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -741,6 +741,11 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@react-native-community/async-storage@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.6.3.tgz#1a713e8c5cacd543ab8539080a5ce57ad917da88"
+  integrity sha512-67K2akX90uc252zKMYJt1wISvaEH6ARtdTI9bUkwmOFXVPyVk1DfPnaRmyUzcVdeCBOO1n0xv9YO2GSppIormQ==
+
 "@react-native-community/cli-platform-android@^3.0.0-alpha.1", "@react-native-community/cli-platform-android@^3.0.0-alpha.7":
   version "3.0.0-alpha.7"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-3.0.0-alpha.7.tgz#03c3671ab72b62a8742aa71b66cb8d594171891f"


### PR DESCRIPTION
react native 官方 将 AsyncStorage 从 react-native 中 抽离成了独立库。
修改了 src/Customize/WithLastDateFooter &&  src/Customize/WithLastDateHeader 中 AsyncStorage 的引用